### PR TITLE
add new index in metrics result and change the parameters passed in Metrics constructor

### DIFF
--- a/bin/thor
+++ b/bin/thor
@@ -174,7 +174,7 @@ live.stop = function stop() {
 //
 // Metrics collection.
 //
-var metrics = new Metrics(cli.amount * cli.args.length);
+var metrics = new Metrics(cli.amount * cli.messages);
 
 // Iterate over all the urls so we can target multiple locations at once, which
 // is helpfull if you are testing multiple loadbalancer endpoints for example.

--- a/metrics.js
+++ b/metrics.js
@@ -144,6 +144,8 @@ Metrics.prototype.summary = function summary() {
   results.writeRow(['Total transferred', this.send.bytes(2)]);
   results.writeRow(['Total received', this.read.bytes(2)]);
 
+  results.writeRow(['Requests per second', (this.requests / this.timing.duration * 1000).toFixed(2) + ' /s'])
+
   // Up next is outputting the series.
   var handshaking = this.handshaking
     , latency = this.latency


### PR DESCRIPTION
1. add 'requests per second' in metrics result, I think the qps might be an important index of benchmark tool.
2. the constructor of ```Metrics``` should be passed the total amount of requests, but actually is ```new Metrics(cli.amount * cli.args.length)```. I think it should be ```new Metrics(cli.amount * cli.messages)```